### PR TITLE
Ticket 77:  resolve create category bug

### DIFF
--- a/json-server.py
+++ b/json-server.py
@@ -178,7 +178,7 @@ class JSONServer(HandleRequests):
         elif url["requested_resource"] == "categories":
             successfully_posted = post_categories(request_body["label"])
             if successfully_posted:
-                return self.response("", status.HTTP_204_SUCCESS_NO_RESPONSE_BODY.value)
+                return self.response(successfully_posted, status.HTTP_201_SUCCESS_CREATED.value)
         elif url["requested_resource"] == "tags":
             successfully_posted = make_tag(request_body["label"])
             if successfully_posted:

--- a/views/category_view.py
+++ b/views/category_view.py
@@ -106,4 +106,7 @@ def post_categories(label):
 
     conn.commit()
     ## Select and return using cursor.lastrow
-    return json.dumps({"id": new_categories_id, "label": label})
+    return json.dumps({
+        'id': new_categories_id,
+        'label': label
+        })


### PR DESCRIPTION
## Ticket:[#77](https://github.com/day-cohort-70/rare-api-rare-bear-team-4/issues/77)


## What Changed:

- changed the if else statement in the Jason server for the categories post request
-  the request now returns a json string.


## Testing Steps:
pull down the branch

run the json server

open the client side and create a new category on the category manager tag in the nav bar. 
the page should add the category, clear the input field  while showing the new category on the left. 

